### PR TITLE
Feature/Configurable GC

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,18 @@ mvn -Pnative clean package
 
 > [!TIP]
 > By default, the native executable uses the G1 garbage collector.
+> However, this garbage collector is only supported on Linux AMD64 or AArch64 systems.
 >
 > You can configure which garbage collector to use by passing:
 > ```bash
-> mvn -Pnative clean package -Dgc=epsilon
+> mvn -Pnative clean package -Dgc=<your-gc>
 > ```
+> The available options are:
+> - `G1` (default)
+> - `epsilon`
+> - `ZGC`
+>
+> For more information, see official [GraalVM Native Image Memory Management docs](https://www.graalvm.org/latest/reference-manual/native-image/optimizations-and-performance/MemoryManagement/).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ mvn -Pnative clean package
 > The available options are:
 > - `G1` (default)
 > - `epsilon`
-> - `ZGC`
+> - `serial`
 >
 > For more information, see official [GraalVM Native Image Memory Management docs](https://www.graalvm.org/latest/reference-manual/native-image/optimizations-and-performance/MemoryManagement/).
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Requires Java 21 or GraalVM 21 for native builds. Native builds are the recommen
 mvn -Pnative clean package
 ```
 
+> [!TIP]
+> By default, the native executable uses the G1 garbage collector.
+>
+> You can configure which garbage collector to use by passing:
+> ```bash
+> mvn -Pnative clean package -Dgc=epsilon
+> ```
+
 ## Installation
 
 After building, copy the native executable to your PATH:
@@ -62,7 +70,7 @@ The tool will analyze the current branch and display statistics for all contribu
 ## Dependencies
 - Java 21 or later
 - Maven
-- GraalVM 21 or later (for native builds)
+- GraalVM 21 (for native builds)
 
 ## Features
 - Fast parallel processing of Git history

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <graalvm.version>21</graalvm.version>
+        <gc>G1</gc>
     </properties>
 
     <dependencies>
@@ -150,7 +151,7 @@
                     <buildArg>--trace-object-instantiation=java.lang.Thread</buildArg>
                     <buildArg>-H:ReflectionConfigurationFiles=${project.basedir}/src/main/resources/META-INF/native-image/reflect-config.json</buildArg>
                     <buildArg>-H:ResourceConfigurationFiles=${project.basedir}/src/main/resources/META-INF/native-image/resource-config.json</buildArg>
-                    <buildArg>--gc=G1</buildArg>
+                    <buildArg>--gc=${gc}</buildArg>
                     <buildArg>-Ob</buildArg>
                 </buildArgs>
             </configuration>


### PR DESCRIPTION
## Garbace Collector selection

This PR adds the possibility to configure the used garbace collector when building a native image through passing `-Dgc=<your-gc>` to the Maven build command.

Example:

```bash
./mvnw -Pnative -Dgc=epsilon clean package
```

> [!NOTE]
> Possible garbage collectors are: 
> - `G1` (default)
> - `epsilon`
> - `serial`
>
> For more information see [GraalVM Native Image Memory Management docs](https://www.graalvm.org/latest/reference-manual/native-image/optimizations-and-performance/MemoryManagement/)

### Implementation details

This feature was done by simply extracting the value of the passed gc `<buildArg>` into its own maven `<property>`.

```xml
<!--Before-->
<buildArg>--gc=G1</buildArg>

<!--After-->
<buildArg>--gc=${gc}</buildArg>

```

### Documentation 

A section that explains how to configure the GC was added to the `README.md`